### PR TITLE
fix typo that prevented search by several sectors

### DIFF
--- a/src/main/java/com/orio/orioapi/web/controller/JobDescriptionUserController.java
+++ b/src/main/java/com/orio/orioapi/web/controller/JobDescriptionUserController.java
@@ -57,7 +57,7 @@ public class JobDescriptionUserController {
 
 
     @GetMapping("/sectors")
-    public ResponseEntity<List<JobDescriptionDto>> getJobDescriptionsBySectors(@RequestParam List<String> sectors) {
+    public ResponseEntity<List<JobDescriptionDto>> getJobDescriptionsBySectors(@RequestParam("sectors") List<String> sectors) {
         Iterable<JobDescription> jobDescriptions = jobDescriptionService.getJobDescriptionsBySectors(sectors);
         if (jobDescriptions != null) {
             List<JobDescriptionDto> jobDescriptionDtoList = jobDescriptionMapper.entitiesToDtoList(iterableToList(jobDescriptions));


### PR DESCRIPTION
in postman when we send several parameters, for example with such url `{{base_url}}/sectors?sectors=gestion&sectors=santé&sectors=aéronautique` before the result contained only Job Descriptions with certain sector from url. After fix search is done by all parameters. 